### PR TITLE
Allow use of refresh even on mobile

### DIFF
--- a/lib/dropkick.js
+++ b/lib/dropkick.js
@@ -938,8 +938,10 @@ Dropkick.prototype = {
    */
   dispose: function() {
     delete Dropkick.cache[ this.data.cacheID ];
-    this.data.elem.parentNode.removeChild( this.data.elem );
-    this.data.select.removeAttribute( "data-dkCacheId" );
+    if (!( isMobile && !this.data.settings.mobile )) {
+      this.data.elem.parentNode.removeChild( this.data.elem );
+      this.data.select.removeAttribute( "data-dkCacheId" );
+    }
     return this;
   },
 


### PR DESCRIPTION
We had an issue where all our JS failed on mobile because we used `.dropkick('refresh')` wich calls `dispose()` wich tries to delete thing that haven't been initialized on mobile.